### PR TITLE
Add explicit provider definition to Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,4 +1,5 @@
 Vagrant.configure("2") do |config|
+  config.vm.provider :virtualbox
   config.vm.box = "punktde/freebsd-120-zfs"
   config.vm.box_version = "12.0.5"
 end


### PR DESCRIPTION
Some operating systems do not use VirtualBox by default.
For example, on Fedora Linux, libvirt is the default provider.