### PR TITLE
Disable Vagrant synced folder

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,4 +1,5 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "punktde/freebsd-120-zfs"
   config.vm.box_version = "12.0.5"
+  config.vm.synced_folder '.', '/vagrant', id: 'vagrant-root', disabled: true
 end


### PR DESCRIPTION
This mount is created by Vagrant automatically by default.
Since we don't need it (and it might be a security risk for the host)
we can disable it.